### PR TITLE
Upgrade Jekyll gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,14 @@ PATH
   specs:
     blog (1.0.0)
       dotenv
-      jekyll (~> 3.5.0)
+      jekyll (~> 3.6.3)
       jekyll-authors
       jekyll-categories
       jekyll-feed
       jekyll-paginate
       jekyll-titleize
       pygments.rb
-      rake (~> 12.0)
+      rake (~> 12.3)
       redcarpet
       sitemap_generator
 
@@ -22,7 +22,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
     byebug (10.0.2)
@@ -31,10 +31,10 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.4)
     diff-lcs (1.3)
-    dotenv (2.5.0)
+    dotenv (2.6.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    ffi (1.9.25)
+    ffi (1.10.0)
     foreman (0.85.0)
       thor (~> 0.19.1)
     forwardable-extended (2.6.0)
@@ -49,16 +49,16 @@ GEM
       yell (~> 2.0)
     i18n (1.3.0)
       concurrent-ruby (~> 1.0)
-    jekyll (3.5.2)
+    jekyll (3.6.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
-      kramdown (~> 1.3)
+      kramdown (~> 1.14)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (~> 1.7)
+      rouge (>= 1.7, < 3)
       safe_yaml (~> 1.0)
     jekyll-authors (0.0.3)
       jekyll (>= 0.10.0)
@@ -109,7 +109,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redcarpet (3.4.0)
-    rouge (1.11.1)
+    rouge (2.2.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -125,12 +125,12 @@ GEM
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.7.2)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sitemap_generator (6.0.1)
+    sitemap_generator (6.0.2)
       builder (~> 3.0)
     slop (3.6.0)
     thor (0.19.4)

--- a/blog.gemspec
+++ b/blog.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/fastruby/blog"
   s.license     = "MIT"
 
-  s.add_dependency('rake', '~> 12.0')
-  s.add_dependency('jekyll', '~> 3.5.0')
+  s.add_dependency('rake', '~> 12.3')
+  s.add_dependency('jekyll', '~> 3.6.3')
   s.add_dependency('jekyll-categories')
   s.add_dependency('jekyll-authors')
   s.add_dependency('jekyll-titleize')


### PR DESCRIPTION
Hey guys,

This PR is upgrading `jekyll` and `rake` versions. 

Jekyll < 3.6.2 has a reported vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-17567.

Please, take a look. Thanks.