### PR TITLE
Add Disqus configuration

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,14 +1,17 @@
 <section class="disqus">
   <div id="disqus_thread"></div>
-  <script type="text/javascript">
-    var disqus_shortname = '{{ site.disqus_shortname }}';
+  <script>
+    var disqus_config = function () {
+      this.page.url = "https://fastruby.disqus.com";
+      this.page.identifier = "fastruby";
+    };
 
     (function() {
-      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+      var d = document, s = d.createElement('script');
+      s.src = 'https://fastruby.disqus.com/embed.js';
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
     })();
   </script>
-  <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-  <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 </section>


### PR DESCRIPTION
Hey guys!

This PR adds the Disqus config to Fast Ruby's blog.

Here is how the section looks like:

<img width="778" alt="screen shot 2019-02-04 at 6 17 38 pm" src="https://user-images.githubusercontent.com/11785031/52234618-3b3dca00-28a9-11e9-90fe-dadcd33ed2ee.png">


Please, check it out. Thanks!