### PR TITLE
Add missing gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
       pygments.rb
       rake (~> 12.3)
       redcarpet
+      rspec
       sitemap_generator
 
 GEM
@@ -157,4 +158,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/blog.gemspec
+++ b/blog.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency('jekyll-feed')
   s.add_dependency('sitemap_generator')
   s.add_dependency('dotenv')
+  s.add_dependency('rspec')
 
   s.add_dependency('pygments.rb')
   s.add_dependency('redcarpet')


### PR DESCRIPTION
Hey guys,

This PR fixes a problem with production deploy described in this story: [163981330](https://www.pivotaltracker.com/n/projects/2200403/stories/163981330).

The `rspec` gem was missing on gemspec.

Thanks!