### PR TITLE
Improve date formatting and display

### DIFF
--- a/_includes/post_meta.html
+++ b/_includes/post_meta.html
@@ -1,7 +1,7 @@
 {%- assign author = site.authors[post.author] -%}
 {%- include author.html -%}
 {%- assign categories = post.categories -%} {%- include category_links.html -%}
-
+<br/>
 <time class="post-date" datetime="{{ post.date | date:'%Y-%m-%d' }}">
-  {{ post.date | date_to_string }}
+  {{ post.date | date: '%B %-d, %Y' }}
 </time>


### PR DESCRIPTION
Hey @cleicar, 

This PR improves the date for all blog posts. 

Before

<img width="411" alt="Screen Shot 2019-04-01 at 11 37 45 PM" src="https://user-images.githubusercontent.com/17584/55374714-79392200-54d7-11e9-902d-ed65547fe5c2.png">

After

<img width="395" alt="Screen Shot 2019-04-01 at 11 36 57 PM" src="https://user-images.githubusercontent.com/17584/55374725-82c28a00-54d7-11e9-9ced-c7ad7dc20993.png">

What do you think? 