### PR TITLE
Change links to point to fastruby.io instead of ombulabs.com

### DIFF
--- a/_posts/2016-10-11-writing-fast-rails.markdown
+++ b/_posts/2016-10-11-writing-fast-rails.markdown
@@ -150,7 +150,7 @@ about [Writing Fast Ruby](https://speakerdeck.com/sferik/writing-fast-ruby): [ht
 great tips for improving performance in your Ruby application or library.
 
 And, if you need help improving the
-[performance](https://www.ombulabs.com/blog/tags/performance) of your Rails
-application, [get in touch](https://www.ombulabs.com/contact)! We are constantly
+[performance](https://fastruby.io/blog/tags/performance) of your Rails
+application, [get in touch](https://fastruby.io/#contact-us)! We are constantly
 looking for new projects and opportunities to improve your
-[Rails](https://www.ombulabs.com/blog/tags/rails) performance.
+[Rails](https://fastruby.io/blog/tags/rails) performance.

--- a/_posts/2017-08-28-upgrade-to-rails-3.markdown
+++ b/_posts/2017-08-28-upgrade-to-rails-3.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "luciano"
 ---
 
-This article is the first of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org) application from [version 2.3](http://guides.rubyonrails.org/2_3_release_notes.html) to [3.0](http://guides.rubyonrails.org/3_0_release_notes.html).
+This article is the first of our [Upgrade Rails series](https://fastruby.io/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org) application from [version 2.3](http://guides.rubyonrails.org/2_3_release_notes.html) to [3.0](http://guides.rubyonrails.org/3_0_release_notes.html).
 
 <!--more-->
 
@@ -174,4 +174,4 @@ lib/tasks/ombulabs_patches/s3_backup.rake
 ```
 
 <h2 id="next-steps">8. Next steps</h2>
-After you get your application properly running in Rails 3.0, you will probably want to keep working on this Rails upgrade journey. So don't forget to check our complete [Rails upgrade series](https://www.ombulabs.com/blog/tags/upgrades) to make that easy.
+After you get your application properly running in Rails 3.0, you will probably want to keep working on this Rails upgrade journey. So don't forget to check our complete [Rails upgrade series](https://fastruby.io/blog/tags/upgrades) to make that easy.

--- a/_posts/2017-10-16-upgrade-to-rails-3-1.md
+++ b/_posts/2017-10-16-upgrade-to-rails-3-1.md
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "luciano"
 ---
 
-This is the second article of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.0](http://guides.rubyonrails.org/3_0_release_notes.html) to [3.1](http://guides.rubyonrails.org/3_1_release_notes.html). If you are in an older version, you can take a look at our [previous article](https://www.ombulabs.com/blog/rails/upgrades/upgrade-to-rails-3.html).
+This is the second article of our [Upgrade Rails series](https://fastruby.io/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.0](http://guides.rubyonrails.org/3_0_release_notes.html) to [3.1](http://guides.rubyonrails.org/3_1_release_notes.html). If you are in an older version, you can take a look at our [previous article](https://fastruby.io/blog/rails/upgrades/upgrade-to-rails-3.html).
 
 <!--more-->
 
@@ -136,4 +136,4 @@ config.static_cache_control = "public, max-age=3600"
 ```
 
 <h2 id="next-steps">7. Next steps</h2>
-After you get your application properly running in Rails 3.1, you will probably want to keep working on this Rails upgrade journey. So don't forget to check our complete [Rails upgrade series](https://www.ombulabs.com/blog/tags/upgrades) to make that easy.
+After you get your application properly running in Rails 3.1, you will probably want to keep working on this Rails upgrade journey. So don't forget to check our complete [Rails upgrade series](https://fastruby.io/blog/tags/upgrades) to make that easy.

--- a/_posts/2017-11-07-upgrade-to-rails-3-2.md
+++ b/_posts/2017-11-07-upgrade-to-rails-3-2.md
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "luciano"
 ---
 
-This is the third article of our [Upgrade Rails series](https://www.ombulabs.com/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.1](http://guides.rubyonrails.org/3_1_release_notes.html) to [3.2](http://guides.rubyonrails.org/3_2_release_notes.html).
+This is the third article of our [Upgrade Rails series](https://fastruby.io/blog/tags/upgrades). We will be covering the most important aspects that you need to know to update your [Ruby on Rails](http://rubyonrails.org/) application from [version 3.1](http://guides.rubyonrails.org/3_1_release_notes.html) to [3.2](http://guides.rubyonrails.org/3_2_release_notes.html).
 
 <!--more-->
 
@@ -70,4 +70,4 @@ end
 Rails 3.2 deprecates `vendor/plugins`, and it's the last Rails version that support it. If your plan is to migrate to Rails 4 in the future, you can start replacing any plugins by extracting them to gems and adding them to your `Gemfile`, or you can move them into `lib/my_plugin/*`. We cover this topic in depth in our Rails 4.0 upgrade guide.
 
 <h2 id="next-steps">7. Next steps</h2>
-After you get your application properly running in Rails 3.2, you will probably want to keep working on this Rails upgrade journey. So don't forget to check our complete [Rails upgrade series](https://www.ombulabs.com/blog/tags/upgrades) to make that easy.
+After you get your application properly running in Rails 3.2, you will probably want to keep working on this Rails upgrade journey. So don't forget to check our complete [Rails upgrade series](https://fastruby.io/blog/tags/upgrades) to make that easy.

--- a/_posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
+++ b/_posts/2017-11-08-upgrade-rails-from-3-2-to-4-0.markdown
@@ -6,9 +6,9 @@ categories: ["rails", "upgrades"]
 author: "mauro-oto"
 ---
 
-_This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.
+_This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
 
-A [previous post](https://www.ombulabs.com/blog/rails/tips-for-upgrading-rails-3-2-to-4.html)
+A [previous post](https://fastruby.io/blog/rails/tips-for-upgrading-rails-3-2-to-4.html)
 covered some general tips to take into account for this migration. This article
 will try to go a bit more in depth. We will first go from 3.2 to 4.0, then to
 4.1 and finally to 4.2. Depending on the complexity of your app, a Rails upgrade

--- a/_posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
+++ b/_posts/2017-11-24-upgrade-rails-from-4-0-to-4-1.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "mauro-oto"
 ---
 
-_This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.
+_This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
 
 This article will cover the most important aspects that you need to know to get
 your [Ruby on Rails](http://rubyonrails.org/) application from [version 4.0](http://guides.rubyonrails.org/4_0_release_notes.html) to [4.1](http://guides.rubyonrails.org/4_1_release_notes.html).
@@ -92,7 +92,7 @@ into the `Gemfile`:
 gem 'activerecord-deprecated_finders'
 ```
 
-See our [last upgrade post](https://www.ombulabs.com/blog/rails/upgrades/upgrade-rails-from-3-2-to-4-0.html) for more information.
+See our [last upgrade post](https://fastruby.io/blog/rails/upgrades/upgrade-rails-from-3-2-to-4-0.html) for more information.
 
 - Default scopes are now chained to other scopes:
 

--- a/_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
+++ b/_posts/2018-02-02-upgrade-rails-from-4-1-to-4-2.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "mauro-oto"
 ---
 
-_This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.
+_This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
 
 This article will cover the most important aspects that you need to know to get
 your [Ruby on Rails](http://rubyonrails.org/) application from [version 4.1](http://guides.rubyonrails.org/4_1_release_notes.html) to [4.2](http://guides.rubyonrails.org/4_2_release_notes.html).

--- a/_posts/2018-02-16-upgrading-a-monolith.markdown
+++ b/_posts/2018-02-16-upgrading-a-monolith.markdown
@@ -20,4 +20,4 @@ We executed a **full upgrade of the application from Rails 4.0 to 5.1** and prep
 
 According to Ben, “Ombu augmented our in-house team with a specific capacity for the upgrade project, **enabling our other developers to retain focus on direct business goals**.” [Ombu Labs](https://www.ombulabs.com)' exclusive focus on the Rails upgrade allowed the developers at [Power Home Remodeling](https://powerhrg.com) to continue their work on features and other goals without distractions. In the end, [Power Home Remodeling](https://powerhrg.com) received an application with up-to-date Rails versions and was able to make progress on their other work as well.
 
-For more information about upgrading your Rails application, check out our "[Upgrade Rails Series](https://www.ombulabs.com/blog/tags/upgrades)", a series of do-it-yourself guides to upgrading Rails.
+For more information about upgrading your Rails application, check out our "[Upgrade Rails Series](https://fastruby.io/blog/tags/upgrades)", a series of do-it-yourself guides to upgrading Rails.

--- a/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
+++ b/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "mauro-oto"
 ---
 
-_This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.
+_This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
 
 This article will cover the most important aspects that you need to know to get
 your [Ruby on Rails](http://rubyonrails.org/) application from [version 4.2](http://guides.rubyonrails.org/4_2_release_notes.html) to [5.0](http://guides.rubyonrails.org/5_0_release_notes.html).

--- a/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
+++ b/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "mauro-oto"
 ---
 
-_This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.
+_This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
 
 This article will cover the most important aspects that you need to know to get
 your [Ruby on Rails](http://rubyonrails.org/) application from [version 5.0](http://guides.rubyonrails.org/5_0_release_notes.html) to [5.1](http://guides.rubyonrails.org/5_1_release_notes.html).
@@ -67,7 +67,7 @@ config.public_file_server.headers = "public, max-age=3600"
 <h3 id="active-record">4.1. ActiveRecord</h2>
 
 - The `raise_in_transactional_callbacks` option is now removed. It was
-already deprecated and covered in a [previous upgrade](https://www.ombulabs.com/blog/rails/upgrades/upgrade-rails-from-4-1-to-4-2.html).
+already deprecated and covered in a [previous upgrade](https://fastruby.io/blog/rails/upgrades/upgrade-rails-from-4-1-to-4-2.html).
 
 - Also removed was `use_transactional_fixtures`, which was [replaced by](https://github.com/rails/rails/pull/19282)
 `use_transactional_tests`.

--- a/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
+++ b/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "upgrades"]
 author: "mauro-oto"
 ---
 
-_This article is part of our Upgrade Rails series. To see more of them, [click here](https://www.ombulabs.com/blog/tags/upgrades)_.
+_This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
 
 This article will cover the most important aspects that you need to know to get
 your [Ruby on Rails](http://rubyonrails.org/) application from [version 5.1](http://guides.rubyonrails.org/5_1_release_notes.html) to [5.2](http://guides.rubyonrails.org/5_2_release_notes.html).

--- a/_posts/2018-10-22-upgrading-a-rails-app.markdown
+++ b/_posts/2018-10-22-upgrading-a-rails-app.markdown
@@ -30,4 +30,4 @@ Ernesto: Okay, and lastly, on a scale from 1-10, how much would you like to work
 
 Ryan: I think that for the right project, I would say a 10.
 
-For more information about upgrading your Rails application, check out our "[Upgrade Rails Series](https://www.ombulabs.com/blog/tags/upgrades)", a series of do-it-yourself guides to upgrading Rails.
+For more information about upgrading your Rails application, check out our "[Upgrade Rails Series](https://fastruby.io/blog/tags/upgrades)", a series of do-it-yourself guides to upgrading Rails.

--- a/_posts/2018-11-14-writing-fast-rails-part-2.markdown
+++ b/_posts/2018-11-14-writing-fast-rails-part-2.markdown
@@ -6,7 +6,7 @@ categories: ["rails", "performance"]
 author: "luciano"
 ---
 
-Some time ago we wrote a couple of [Tips for Writing Fast Rails](https://www.ombulabs.com/blog/performance/rails/writing-fast-rails.html). It was about time we wrote part two so here it is!
+Some time ago we wrote a couple of [Tips for Writing Fast Rails](https://fastruby.io/blog/performance/rails/writing-fast-rails.html). It was about time we wrote part two so here it is!
 
 <!--more-->
 


### PR DESCRIPTION
Hey @ercohen14, 

This PR updates references to fastruby.io instead of ombulabs.com

Please check it out.

Thanks! 