### PR TITLE
Remove padding and border to the left of the date

### DIFF
--- a/assets/css/screen.scss
+++ b/assets/css/screen.scss
@@ -804,10 +804,6 @@ body:not(.post-template) .post-title {
 
 .post-meta time.post-date {
   display: inline-block;
-  margin-left: 8px;
-  padding-left: 12px;
-  border-left: #d5dbde 1px solid;
-  text-transform: uppercase;
   font-size: 1.3rem;
   white-space: nowrap;
 }


### PR DESCRIPTION
Hey, 

This PR improves the UI for the post's date.

Before:

![Screen Shot 2019-04-21 at 5 22 50 PM](https://user-images.githubusercontent.com/17584/56476232-e0a51a80-6462-11e9-87ee-dc19498f68de.png)

After:

![Screen Shot 2019-04-21 at 5 25 19 PM](https://user-images.githubusercontent.com/17584/56476241-003c4300-6463-11e9-84cd-9b7363cf929b.png)

