### PR TITLE
[#168528707] Timestamp position

### DIFF
--- a/_includes/post_excerpt.html
+++ b/_includes/post_excerpt.html
@@ -1,5 +1,8 @@
   <article class="post">
     <div class="post-header">
+      <h1>
+        <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      </h1>
       <div class="date-info">
         <time datetime="{{ post.date | date:'%Y-%m-%d' }}">
           Created at: {{ post.date | date: '%B %-d, %Y' }}
@@ -12,9 +15,6 @@
           {% endif %}
         </time>
       </div>
-      <h1>
-        <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-      </h1>
     </div>
     <div class="post-meta">
       {%- include post_meta.html -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,6 +8,7 @@ post_class: post-template
 <main id="content" class="post-layout col-xs-12 order-xs-2 col-md-8" role="main">
   <article class="post">
     <div class="post-header">
+      <h1 class="post-title">{{ page.title }}</h1>
       <div class="date-info">
         <time datetime="{{ page.date | date:'%Y-%m-%d' }}">
           Created at: {{ page.date | date: '%B %-d, %Y' }}
@@ -20,7 +21,6 @@ post_class: post-template
           {% endif %}
         </time>
       </div>
-      <h1 class="post-title">{{ page.title }}</h1>
       <section class="post-meta">
         {%- include post_meta.html -%}
       </section>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,3 +11,7 @@
 @import
 	"syntax"
 ;
+
+.date-info{
+	margin-top: 1rem;
+}


### PR DESCRIPTION
This PR: 

- Changes the timestamp position.

How it looks now:
<img width="726" alt="Screen Shot 2019-09-17 at 16 51 58" src="https://user-images.githubusercontent.com/8450941/65074561-7e960600-d96b-11e9-84f5-33cdd4287dc1.png">

How it will look after this PR:
<img width="762" alt="Screen Shot 2019-09-17 at 16 51 44" src="https://user-images.githubusercontent.com/8450941/65074567-805fc980-d96b-11e9-8b7b-32dd560716c3.png">

Pivotal story reference: https://www.pivotaltracker.com/story/show/168528707