### PR TITLE
Remove jekyll-last-modified-at

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       jekyll-authors
       jekyll-categories
       jekyll-feed
-      jekyll-last-modified-at
       jekyll-paginate
       jekyll-titleize
       pygments.rb
@@ -66,9 +65,6 @@ GEM
       jekyll (>= 0.10.0)
     jekyll-feed (0.12.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-last-modified-at (1.1.0)
-      jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
@@ -91,7 +87,6 @@ GEM
     parallel (1.17.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.13)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,6 @@ exclude: [vendor]
 plugins:
   - jekyll-paginate
   - jekyll-feed
-  - jekyll-last-modified-at
 
 sass:
   style: compressed

--- a/_includes/post_excerpt.html
+++ b/_includes/post_excerpt.html
@@ -7,13 +7,6 @@
         <time datetime="{{ post.date | date:'%Y-%m-%d' }}">
           Created at: {{ post.date | date: '%B %-d, %Y' }}
         </time>
-        <time id="last-modified-at">
-          {% assign last_modified_at = post.last_modified_at | date: '%s' | date: '%B %-d, %Y' %}
-          {% assign post_date = post.date | date: '%s'| plus: 86400 | date: '%B %-d, %Y'%}
-          {% if last_modified_at > post_date %}
-          - Updated at: {{ post.last_modified_at | date: '%B %-d, %Y' }}
-          {% endif %}
-        </time>
       </div>
     </div>
     <div class="post-meta">

--- a/blog.gemspec
+++ b/blog.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.add_dependency('jekyll-titleize')
   s.add_dependency('jekyll-paginate')
   s.add_dependency('jekyll-feed')
-  s.add_dependency('jekyll-last-modified-at')
   s.add_dependency('dotenv')
   s.add_dependency('rspec')
 


### PR DESCRIPTION
1. The plugin doesn't work on Heroku, because the plugin picks the date from git but it seems heroku deletes the .git directory as part of their process before building the project, so the plugin doesn't have access to use the git dates.

2. If no git reference of is found the plugin will try to get the mtime of the file, but since heroku process involves moving files to an app directory all the files mtime will be set to the time this action happens, leading     to putting all the blogposts last_modified_at field to the same time the blog was deployed.

I'm removing the use of this plugin and the last_modified_at functionality since it doesn't work with our current deployment process.

We will have to find a way to manage it our selves or find another plugin.