### PR TITLE
Make sure that we include categories and author in the author page

### DIFF
--- a/_includes/post_excerpt.html
+++ b/_includes/post_excerpt.html
@@ -1,11 +1,11 @@
   <article class="post">
     <div class="post-header">
       <h1>
-        <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
       </h1>
       <div class="date-info">
-        <time datetime="{{ post.date | date:'%Y-%m-%d' }}">
-          Created at: {{ post.date | date: '%B %-d, %Y' }}
+        <time datetime="{{ page.date | date:'%Y-%m-%d' }}">
+          Created at: {{ page.date | date: '%B %-d, %Y' }}
         </time>
       </div>
     </div>
@@ -13,6 +13,6 @@
       {%- include post_meta.html -%}
     </div>
     <section class="post-excerpt">
-      {{ post.excerpt | markdownify }} <a class="btn" href="{{ post.url | prepend: site.baseurl }}">Read more</a>
+      {{ page.excerpt | markdownify }} <a class="btn" href="{{ page.url | prepend: site.baseurl }}">Read more</a>
     </section>
   </article>

--- a/_includes/post_meta.html
+++ b/_includes/post_meta.html
@@ -1,5 +1,4 @@
-{%- assign author = site.authors[post.author] -%}
-{%- assign authors = post.authors -%}
+{%- assign author = site.authors[page.author] -%}
 {%- include author.html -%}
-{%- assign categories = post.categories -%} 
+{%- assign categories = page.categories -%}
 {%- include category_links.html -%}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ meta:
     {%- include pagination.html -%}
   </div>
 
-  {%- for post in paginator.posts -%}
+  {%- for page in paginator.posts -%}
     {%- include post_excerpt.html -%}
   {%- endfor -%}
 


### PR DESCRIPTION
Hey @lubc, 

This PR fixes an issue with missing content in the post page. See: https://www.pivotaltracker.com/story/show/169455770

HTML for the index page:

<img width="1211" alt="Screen Shot 2019-10-29 at 8 31 21 PM" src="https://user-images.githubusercontent.com/17584/67877204-866ecb80-fb0f-11e9-9276-cac85016b6ca.png">

HTML for the post page: 

<img width="1214" alt="Screen Shot 2019-10-29 at 8 31 28 PM" src="https://user-images.githubusercontent.com/17584/67877217-8cfd4300-fb0f-11e9-859f-cd70ef01609c.png">

Please check it out. 

Thanks! 

