### PR TITLE
Revert "Make sure that we include categories and author in the author page"

### DIFF
--- a/_includes/post_excerpt.html
+++ b/_includes/post_excerpt.html
@@ -1,11 +1,11 @@
   <article class="post">
     <div class="post-header">
       <h1>
-        <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+        <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
       </h1>
       <div class="date-info">
-        <time datetime="{{ page.date | date:'%Y-%m-%d' }}">
-          Created at: {{ page.date | date: '%B %-d, %Y' }}
+        <time datetime="{{ post.date | date:'%Y-%m-%d' }}">
+          Created at: {{ post.date | date: '%B %-d, %Y' }}
         </time>
       </div>
     </div>
@@ -13,6 +13,6 @@
       {%- include post_meta.html -%}
     </div>
     <section class="post-excerpt">
-      {{ page.excerpt | markdownify }} <a class="btn" href="{{ page.url | prepend: site.baseurl }}">Read more</a>
+      {{ post.excerpt | markdownify }} <a class="btn" href="{{ post.url | prepend: site.baseurl }}">Read more</a>
     </section>
   </article>

--- a/_includes/post_meta.html
+++ b/_includes/post_meta.html
@@ -1,4 +1,5 @@
-{%- assign author = site.authors[page.author] -%}
+{%- assign author = site.authors[post.author] -%}
+{%- assign authors = post.authors -%}
 {%- include author.html -%}
-{%- assign categories = page.categories -%}
+{%- assign categories = post.categories -%} 
 {%- include category_links.html -%}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ meta:
     {%- include pagination.html -%}
   </div>
 
-  {%- for page in paginator.posts -%}
+  {%- for post in paginator.posts -%}
     {%- include post_excerpt.html -%}
   {%- endfor -%}
 


### PR DESCRIPTION
Hey @lubc, 

I noticed an issue with this PR. For example: 

<img width="1178" alt="Screen Shot 2019-10-30 at 2 47 29 PM" src="https://user-images.githubusercontent.com/17584/67889094-9cd35200-fb24-11e9-8902-e45013f0329a.png">

For a page like this one: 

So we will have to revert fastruby/blog#51 for now. 👍 