### PR TITLE
[#169438065] Changed blog header to match FastRuby look and feel

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,20 @@
+<header>
+  <nav class="navbar navbar-expand-md">
+    <a class="navbar-brand" href="{{ site.baseurl }}">
+      <img src="{{site.baseurl}}/assets/images/fastruby-logo.svg">
+      <span><strong>Fast</strong>Ruby Blog</span>
+    </a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+      <div class="navbar-nav">
+        <a class="nav-item nav-link btn-link" href="https://www.fastruby.io/">Go to FastRuby.io</a>
+        <a class="nav-item nav-link btn icon-feed" href="{ site.baseurl }}/rss.xml"></a>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,24 +55,8 @@
   <link rel="stylesheet" type="text/css" href="/assets/fastruby_blog/application.css" />
 </head>
 <body class="{%- if page.post_class -%}{{page.post_class}}{%- else -%}home-template{%- endif -%}">
-  <header class="main-header {% if page.cover %}" style="background-image: url({{ page.cover }}) {%else%}no-cover{%- endif -%}">
-    <nav class="main-nav overlay clearfix">
-      {%- if page.logo -%}
-        <a class="blog-logo" href="{{ site.baseurl }}">
-          <img src="{{ page.logo }}" alt="Blog Logo" />
-        </a>
-      {%- endif -%}
-      <a class="back-button icon-arrow-left"
-        href="{%- if page.url == '/' -%}{{ site.domain_name }}{%- else -%}{{ site.baseurl }}{%- endif -%}"><span>Home</span></a>
-      <a class="subscribe-button icon-feed" href="{{ site.baseurl }}/rss.xml"><span>Subscribe</span></a>
-    </nav>
-    <div class="vertical">
-      <div class="main-header-content inner">
-        <h2><a href="{{ site.baseurl }}"><img src="{{site.baseurl}}/assets/images/fastruby-logo.svg">{{ site.name }}</a></h2>
-      </div>
-    </div>
-    <a class="scroll-down icon-arrow-left" href="#content" data-offset="-45"><span class="hidden">Scroll Down</span></a>
-  </header>
+  
+    {%- include header.html -%}
     <div id="wrapper">
       {%- include sidebar.html -%}
       {{ content }}
@@ -81,8 +65,10 @@
 
     {%- include site_footer.html -%}
 
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/fitvids/1.1.0/jquery.fitvids.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     <script type="text/javascript" src="{{ site.baseurl }}/assets/js/index.js"></script>
 
     <!-- Google Analytics Tracking code -->

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -56,7 +56,7 @@
 
     $document.scroll(function(){
 
-        var headerHeight = $(".main-header").outerHeight();
+        var headerHeight = $("header").outerHeight();
         var scrollTop = $(document).scrollTop();
         var viewportWidth = $(document).width();
 
@@ -69,11 +69,15 @@
         }
         
         if(scrollTop <= headerHeight){
-            $(".main-header").removeClass("fixed");
+            $("header").removeClass("fixed");
         }else if(scrollTop > headerHeight){
-            $(".main-header").addClass("fixed");
+            $("header").addClass("fixed");
         }
       
     })
+
+    $('.navbar-toggler').click(function(){
+        $(this).toggleClass('open');
+    });
     
 })(jQuery);


### PR DESCRIPTION
This PR:
- Changes blog's header to match FastRuby look and feel.

How it looks right now:
<img width="1440" alt="Screen Shot 2019-11-06 at 10 27 15" src="https://user-images.githubusercontent.com/8450941/68302250-65aef480-0080-11ea-9b52-1457a3b54a77.png">

How it will look after this PR:
<img width="1440" alt="Screen Shot 2019-11-06 at 10 27 17" src="https://user-images.githubusercontent.com/8450941/68302282-72334d00-0080-11ea-9034-00ca95e69c08.png">
