### PR TITLE
Fixes missing post meta in post's page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,6 +22,7 @@ post_class: post-template
         </time>
       </div>
       <section class="post-meta">
+        {%- assign post = page -%}
         {%- include post_meta.html -%}
       </section>
     </div>


### PR DESCRIPTION
Hey @lubc @nykka, 

This PR fixes https://www.pivotaltracker.com/story/show/169455770

<img width="871" alt="Screen Shot 2019-11-10 at 9 30 32 PM" src="https://user-images.githubusercontent.com/17584/68556950-473f5500-0402-11ea-8224-00ed09921ce8.png">
<img width="875" alt="Screen Shot 2019-11-10 at 9 30 37 PM" src="https://user-images.githubusercontent.com/17584/68556951-473f5500-0402-11ea-9aab-92210cacf15b.png">
<img width="878" alt="Screen Shot 2019-11-10 at 9 30 57 PM" src="https://user-images.githubusercontent.com/17584/68556952-473f5500-0402-11ea-9b50-1bde9d5c24a4.png">


Please check it out.

Thanks! 