### PR TITLE
Move tags list to the end of the post's page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -41,9 +41,6 @@ post_class: post-template
         </ul>
       </section>
     {%- endif -%}
-    <div>
-      {%- include tag_list.html -%}
-    </div>
     <div class="post-footer">
       {%- if page.author -%}
         {%- assign author = site.authors[page.author] -%}
@@ -70,7 +67,9 @@ post_class: post-template
 
       <!-- Disqus comments -->
       {%- include disqus.html -%}
-
+    </div>
+    <div>
+      {%- include tag_list.html -%}
     </div>
 
   </article>


### PR DESCRIPTION
Hey,

This solves this bug: https://www.pivotaltracker.com/story/show/172515272

This section is not as important as showing who wrote the article or the comments.

This is what it will look like: 

## Desktop 

![Screen Shot 2020-04-25 at 9 51 01 AM](https://user-images.githubusercontent.com/17584/80281705-0a7ac800-86db-11ea-85df-7e8ffe6b1111.png)

## Mobile 

![Screen Shot 2020-04-25 at 9 51 25 AM](https://user-images.githubusercontent.com/17584/80281706-0b135e80-86db-11ea-9083-887e59dfc762.png)

So I think it should go last. Thoughts? 

Thanks,
Ernesto