### PR TITLE
[#172294837] Images missing alt tag

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,11 @@
 <header>
   <nav class="navbar navbar-expand-md">
     <a class="navbar-brand" href="{{ site.baseurl }}">
-      <img src="{{site.baseurl}}/assets/images/fastruby-logo.svg">
+      <img src="{{site.baseurl}}/assets/images/fastruby-logo.svg" alt="FastRuby.io Logo">
       <span><strong>Fast</strong>Ruby Blog</span>
     </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup"
+      aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
       <span></span>
       <span></span>
       <span></span>

--- a/_posts/2019-09-11-how-to-stay-up-to-date.markdown
+++ b/_posts/2019-09-11-how-to-stay-up-to-date.markdown
@@ -45,7 +45,7 @@ You can use `bundle outdated` to check outdated gems in your current bundle. Whi
 You can still install Dependabot from the Github Marketplace until it's integrated into GitHub
 
 <div style="text-align: center; width: 500px;">
-  <img src="/blog/assets/images/dependabot/dependabot.png">
+  <img src="/blog/assets/images/dependabot/dependabot.png" alt="Dependabot screenshot">
 </div>
 
 We know not all of you use Github but if it happens that you do use it, dependabot would be a really nice addition to your tools to keep you up to date.


### PR DESCRIPTION
**What is this PR:**

[] Bug fix
[] Feature
[x] Chore

**Description:**

This PR adds missing alt="" tags to <img> elements.

**Related story:**

https://www.pivotaltracker.com/story/show/172294837

**Related links (if applicable):**

Semrush audit https://www.semrush.com/siteaudit/campaign/3544005/review/#issue/detail/110/sorting/index_asc/page/1/filter/%2B|source_url|Co|https%3A%2F%2Fwww.fastruby.io

W3 documentation regarding decorative images
https://www.w3.org/WAI/tutorials/images/decorative/

**How has this been tested?**

[] Automated tests
[x] Manual tests

**What manual tests have been run?**

Tested in all browsers.

**What browsers did you test it on (if applicable)?**

[x] Chrome
[x] Firefox
[] Edge
[x] Safari