### PR TITLE
Shifts the first tag

### DIFF
--- a/_includes/tag_list.html
+++ b/_includes/tag_list.html
@@ -10,7 +10,7 @@
       {%- endfor -%}
     {%- endfor -%}
 
-    {%- assign list = tags | split: ';' | sort -%}
+    {%- assign list = tags | split: ';' | sort | shift -%}
     {%- for category in list -%}
         <h3 class="tag-name">
           <a href="{{ site.baseurl }}/tags/{{ category | downcase | replace: ' ','-' }}"


### PR DESCRIPTION
Pivotal Story Reference: https://www.pivotaltracker.com/story/show/173731495

This PR:

- Shifts the first tag from the tag's list since it's an empty one.

**This fix was already made but I don't know why this change is not reflected on master https://github.com/fastruby/blog/pull/180/commits/634e05d01fd967464de6f71fff13b9cc5926d936**
