### PR TITLE
Change http to https for gravatar

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -4,7 +4,7 @@
       {%- if author.gravatar -%}
       <img
         class="author-thumb"
-        src="http://2.gravatar.com/avatar/{{ author.gravatar }}?s=50"
+        src="https://secure.gravatar.com/avatar/{{ author.gravatar }}?s=50"
         alt="{{ author.display_name }}"
         nopin="nopin"
       />
@@ -29,17 +29,17 @@
     </div>
   </div>
 
-{%- endif -%} 
+{%- endif -%}
 
-{%- if authors -%} 
-  {% for author in authors %} 
+{%- if authors -%}
+  {% for author in authors %}
     {%- assign author_info = site.authors[author] -%}
     <div class="author-block">
       <div class="author-photo">
         {%- if author_info.gravatar -%}
         <img
           class="author-thumb"
-          src="http://2.gravatar.com/avatar/{{ author_info.gravatar }}?s=50"
+          src="https://secure.gravatar.com/avatar/{{ author_info.gravatar }}?s=50"
           alt="{{ author_info.display_name }}"
           nopin="nopin"
         />
@@ -63,23 +63,23 @@
       </div>
     </div>
 
-    {%- if authors.size == 2 -%} 
+    {%- if authors.size == 2 -%}
       {%- unless forloop.last -%}
         <div class="author-and">and</div>
-      {%- endunless -%} 
-    {%- else -%} 
-      {% if forloop.first == true %} 
+      {%- endunless -%}
+    {%- else -%}
+      {% if forloop.first == true %}
         {%- unless forloop.last -%}
           <div>,</div>
-        {%- endunless -%} 
-      {%- else -%} 
+        {%- endunless -%}
+      {%- else -%}
         {%- unless forloop.last -%}
           <div class="author-and">and</div>
-        {%- endunless -%} 
-      {%- endif -%} 
-    {%- endif -%} 
-  {% endfor %} 
+        {%- endunless -%}
+      {%- endif -%}
+    {%- endif -%}
+  {% endfor %}
   <div class="author-info">
     {%- include category_links.html -%}
   </div>
-{%- endif -%} 
+{%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,7 +38,7 @@ post_class: post-template
         <div class="post-footer">
           <figure class="author-image">
             {%- if author.gravatar -%}
-              <a class="img" href="{{ page.baseurl }}" style="background-image: url(//2.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
+              <a class="img" href="{{ page.baseurl }}" style="background-image: url(//secure.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
               <span class="hidden">{{author.display_name}}'s Picture</span></a>
             {%- else -%}
               <a class="img" href="{{ page.baseurl }}" style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
@@ -51,7 +51,7 @@ post_class: post-template
               {% if author.bio %}
                 {{ author.bio }}
               {% else %}
-              If you need help with your Rails upgrade project, contact us! 
+              If you need help with your Rails upgrade project, contact us!
               <a href="https://www.fastruby.io" title="Upgrade Rails">FastRuby.io provides a top-notch Rails upgrade service</a> so you can focus on features.
               {% endif %}
               {%- if author.twitter -%}If you enjoyed this article, <a href="https://twitter.com/{{ author.twitter }}" title="Follow {{ author.name }} on Twitter" target="_blank">follow me on Twitter!</a>{%- endif -%}
@@ -61,13 +61,13 @@ post_class: post-template
       {%- endif -%}
 
 
-      {%- if page.authors -%} 
-        {% for author in page.authors %} 
+      {%- if page.authors -%}
+        {% for author in page.authors %}
           {%- assign author_info = site.authors[author] -%}
           <div class="post-footer">
             <figure class="author-image">
               {%- if author_info.gravatar -%}
-                <a class="img" href="{{ page.baseurl }}" style="background-image: url(//2.gravatar.com/avatar/{{ author_info.gravatar }}?s=50)">
+                <a class="img" href="{{ page.baseurl }}" style="background-image: url(//secure.gravatar.com/avatar/{{ author_info.gravatar }}?s=50)">
                 <span class="hidden">{{author_info.display_name}}'s Picture</span></a>
               {%- else -%}
                 <a class="img" href="{{ page.baseurl }}" style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
@@ -80,14 +80,14 @@ post_class: post-template
                 {% if author_info.bio %}
                   {{ author_info.bio }}
                 {% else %}
-                If you need help with your Rails upgrade project, contact us! 
+                If you need help with your Rails upgrade project, contact us!
                 <a href="https://www.fastruby.io" title="Upgrade Rails">FastRuby.io provides a top-notch Rails upgrade service</a> so you can focus on features.
                 {% endif %}
                 {%- if author_info.twitter -%}If you enjoyed this article, <a href="https://twitter.com/{{ author_info.twitter }}" title="Follow {{ author_info.name }} on Twitter" target="_blank">follow me on Twitter!</a>{%- endif -%}
               </p>
             </section>
           </div>
-        {% endfor %} 
+        {% endfor %}
       {%- endif -%}
 
     <div class="post-footer">


### PR DESCRIPTION
This is PR changes http://2.gravatar.com/avatar to https://secure.gravatar.com/avatar

This is currently deployed to staging and seems to be working. 

This will hopefully address this story:
https://www.pivotaltracker.com/story/show/174626376