### PR TITLE
Update Ruby/Rails compatibility table 

### DIFF
--- a/_posts/2019-04-29-compatibility-table.md
+++ b/_posts/2019-04-29-compatibility-table.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Ruby & Rails Compatibility Table"
 date: 2019-04-29 13:00:00
-reviewed: 2020-04-24 10:00:00
+reviewed: 2020-09-16 10:00:00
 categories: ["ruby", "rails", "versions"]
 author: "etagwerker"
 ---
@@ -28,35 +28,35 @@ Rails we have ran into a lot of these combinations.
     <tr>
       <td>6.1.0</td>
       <td>&gt;= 2.5.0</td>
-      <td></td>
+      <td>2.7.1</td>
       <td>&gt;= 1.8.11</td>
       <td>Alpha</td>
     </tr>
     <tr>
       <td>6.0.x</td>
-      <td>&gt;= 2.5.0</td>
-      <td></td>
+      <td>&gt;= 2.5.0<br/><a href="https://github.blog/2020-08-25-upgrading-github-to-ruby-2-7/" target="_blank">&lt; 3.0.0</a></td>
+      <td>2.6.6</td>
       <td>&gt;= 1.8.11</td>
       <td>Maintained</td>
     </tr>
     <tr>
       <td>5.2.x</td>
-      <td>&gt;= 2.2.2</td>
-      <td></td>
+      <td>&gt;= 2.2.2<br/><a href="https://github.com/rails/rails/blob/v5.2.4.4/.travis.yml#L65-L68" target="_blank">&lt; 2.6.0</a></td>
+      <td>2.5.8</td>
       <td>&gt;= 1.8.11</td>
       <td>Maintained for Security Issues</td>
     </tr>
     <tr class="eol">
       <td>5.1.x</td>
-      <td>&gt;= 2.2.2</td>
-      <td></td>
+      <td>&gt;= 2.2.2<br/><a href="https://github.com/rails/rails/blob/v5.1.7/.travis.yml#L54-L58" target="_blank">&lt; 2.6.0</a></td>
+      <td>2.5.8</td>
       <td>&gt;= 1.8.11</td>
       <td><a href="https://weblog.rubyonrails.org/2019/8/15/Rails-6-0-final-release/" style="color:white">EOL</a></td>
     </tr>
     <tr class="eol">
       <td>5.0.x</td>
-      <td>&gt;= 2.2.2</td>
-      <td></td>
+      <td>&gt;= 2.2.2</br><a href="https://github.com/rails/rails/issues/31478" target="_blank">&lt; 2.5.0</a></td>
+      <td>2.4.10</td>
       <td>&gt;= 1.8.11</td>
       <td><a href="https://weblog.rubyonrails.org/2019/8/15/Rails-6-0-final-release/" style="color:white">EOL</a></td>
     </tr>
@@ -112,11 +112,20 @@ Rails we have ran into a lot of these combinations.
   </tbody>
 </table>
 
+To find more information about the most recent Ruby releases check out this 
+page: [Ruby Releases](https://www.ruby-lang.org/en/downloads/releases/)
+
 ## Need to Upgrade Rails?
 
 If you want to upgrade Rails, check out our series of articles that cover from Rails 2.3 to Rails 6.0: [Articles by FastRuby.io about Rails upgrades](https://www.fastruby.io/blog/tags/upgrades)
 
-If you don't have the time to do it yourself and you have a budget to hire our team, send us a message over here: [Contact FastRuby.io](https://www.fastruby.io/#contactus)
+If you don't have the time to do it yourself you can hire our team to do it for you,
+send us a message over here: [Contact FastRuby.io | Rails Upgrade Service](https://www.fastruby.io/#contactus)
+
+## The Complete Guide to Upgrade Rails (eBook)
+
+If you want to download our ebook (which covers steps from Rails 2.3 to Rails 6.0)
+we will be happy to mail you a free copy: [Download The Complete Guide to Upgrade Rails](https://www.fastruby.io)
 
 ## Feedback Wanted: Updates
 


### PR DESCRIPTION
Hey,

Some Ruby versions are not compatible with Rails (e.g. You can't use Ruby 2.5 with Rails 5.0) so I figured we could track that information as well.

Also, I added more recommended Ruby versions to the table. 

Please check it out.

Thanks! 
