### PR TITLE
Update/rails 5.0 to rails 5.1 article

### DIFF
--- a/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
+++ b/_posts/2018-03-06-upgrade-rails-from-4-2-to-5-0.markdown
@@ -2,9 +2,9 @@
 layout: post
 title: "Upgrade Rails from 4.2 to 5.0"
 date: 2018-03-06 10:53:00
-reviewed: 2020-03-05 10:00:00
+reviewed: 2020-09-17 10:00:00
 categories: ["rails", "upgrades"]
-author: "mauro-oto"
+authors: ["etagwerker", "mauro-oto"]
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
@@ -40,12 +40,12 @@ to your `Gemfile`.
 
 <h2 id="gems">2. Gems</h2>
 
-- It's recommended that you check your `Gemfile` against [Ready4Rails](http://www.ready4rails.net)
+- It's recommended that you check your `Gemfile` against [RailsBump](https://www.railsbump.org)
 to ensure all your gems are compatible with Rails 5.
 As of the release of this blog post, there are only a few gems which don't
 support Rails 5 yet. This is more of a problem when you're upgrading early on.
 
-If any of the gems are missing on Ready4Rails, you'll need to manually check the
+If any of the gems are missing on RailsBump, you'll need to manually check the
 Github page for the project to find out its status. In case you own the gem,
 you'll need to make sure it works on Rails 5 or update it.
 

--- a/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
+++ b/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
@@ -32,9 +32,18 @@ If you want to know more about the Ruby versions that you could use, check out o
 
 <h2 id="gems">2. Gems</h2>
 
-- Make sure the gems you use are compatible with Rails 5.1, you can check this
-using [RailsBump](https://www.railsbump.org). If a gem is missing on
-RailsBump, you'll need to manually check the Github page for the project to
+Make sure the gems you use are compatible with Rails 5.1, you can check this
+using [RailsBump](https://www.railsbump.org).
+
+If you can't find the gem in RailsBump, you could try using `next_rails` to
+find incompatibilities in your dependencies:
+
+```
+gem install next_rails
+bundle_report compatibility --rails-version=5.1.0
+```
+
+If that does not work, you'll need to manually check the GitHub page for the project to
 find out its status. In case you own the gem, you'll need to make sure it
 supports Rails 5.1 and if it doesn't, update it.
 
@@ -88,7 +97,9 @@ After:
 
 ```ruby
 config.public_file_server.enabled = false
-config.public_file_server.headers = "public, max-age=3600"
+config.public_file_server.headers = {
+  'Cache-Control' => "public, max-age=3600"
+}
 ```
 
 <h2 id="application-code">4. Application code</h2>

--- a/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
+++ b/_posts/2018-06-29-upgrade-rails-from-5-0-to-5-1.markdown
@@ -2,9 +2,9 @@
 layout: post
 title: "Upgrade Rails from 5.0 to 5.1"
 date: 2018-07-18 10:05:00
-reviewed: 2020-03-05 10:00:00
+reviewed: 2020-09-17 10:00:00
 categories: ["rails", "upgrades"]
-author: "mauro-oto"
+authors: ["etagwerker", "mauro-oto"]
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
@@ -27,11 +27,14 @@ your [Ruby on Rails](http://rubyonrails.org/) application from [version 5.0](htt
 
 Like Rails 5.0, [Rails 5.1](https://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/) requires [Ruby 2.2.2](https://www.ruby-lang.org/en/news/2015/04/13/ruby-2-2-2-released/) or later.
 
+If you want to know more about the Ruby versions that you could use, check out our
+[Ruby & Rails Compatibility Table](https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html).
+
 <h2 id="gems">2. Gems</h2>
 
 - Make sure the gems you use are compatible with Rails 5.1, you can check this
-using [Ready4Rails](http://www.ready4rails.net). If a gem is missing on
-Ready4Rails, you'll need to manually check the Github page for the project to
+using [RailsBump](https://www.railsbump.org). If a gem is missing on
+RailsBump, you'll need to manually check the Github page for the project to
 find out its status. In case you own the gem, you'll need to make sure it
 supports Rails 5.1 and if it doesn't, update it.
 
@@ -41,7 +44,32 @@ Rails includes the `rails app:update` [task](http://edgeguides.rubyonrails.org/u
 You can use this task as a guideline as explained thoroughly in
 [this post](http://thomasleecopeland.com/2015/08/06/running-rails-update.html).
 
-As an alternative, check out [RailsDiff](http://railsdiff.org/5.0.7/5.1.6),
+You might run into an error trying to run that command:
+
+```
+$ bundle exec rails app:update
+rails aborted!
+LoadError: cannot load such file -- rails/commands/server
+/Users/etagwerker/.rvm/gems/ruby-2.4.9@ombu/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:34:in `require'
+/Users/etagwerker/.rvm/gems/ruby-2.4.9@ombu/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:292:in `block in require'
+/Users/etagwerker/.rvm/gems/ruby-2.4.9@ombu/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:258:in `load_dependency'
+/Users/etagwerker/.rvm/gems/ruby-2.4.9@ombu/gems/activesupport-5.1.7/lib/active_support/dependencies.rb:292:in `require'
+/Users/etagwerker/Projects/ombulabs/ombushop/config/application.rb:5:in `<main>'
+```
+
+If that is the case, you will need to change this require statement:
+
+```ruby
+require 'rails/commands/server'
+```
+
+To:
+
+```ruby
+require 'rails/commands/server/server_command'
+```
+
+As an alternative, check out [RailsDiff](http://railsdiff.org/5.0.7.2/5.1.7),
 which provides an overview of the changes in a basic Rails app between 5.0.x and
 5.1.x (or any other source/target versions). Always target your upgrade to the
 latest patch version (e.g: 5.1.6 instead of 5.1.0).

--- a/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
+++ b/_posts/2018-07-26-upgrade-rails-from-5-1-to-5-2.markdown
@@ -2,9 +2,9 @@
 layout: post
 title: "Upgrade Rails from 5.1 to 5.2"
 date: 2018-08-14 12:42:00
-reviewed: 2020-03-05 10:00:00
+reviewed: 2020-09-17 10:00:00
 categories: ["rails", "upgrades"]
-author: "mauro-oto"
+authors: ["etagwerker", "mauro-oto"]
 ---
 
 _This article is part of our Upgrade Rails series. To see more of them, [click here](https://fastruby.io/blog/tags/upgrades)_.
@@ -30,7 +30,7 @@ Like Rails 5.0 and 5.1, [Rails 5.2](https://weblog.rubyonrails.org/2018/4/9/Rail
 
 At the time of writing, the Rails 5.2 release is relatively recent, which
 means that some gems may still not be fully compatible, or contain deprecation
-warnings if you're not using their latest version. [Ready4Rails](http://www.ready4rails.net)
+warnings if you're not using their latest version. [RailsBump](https://www.railsbump.org)
 can help you check if the gem is compatible with Rails 5.0, but it may have
 annoying bugs/deprecation warnings on 5.2. Some (popular) gem examples are:
 


### PR DESCRIPTION
Hey, 

This PR updates references to RailsBump and it adds a section to the [Rails 5.0 to 5.1 article](https://www.fastruby.io/blog/rails/upgrades/upgrade-rails-from-5-0-to-5-1) 
Please check it out.

Thanks! 