### PR TITLE
Add canonical link to the head section

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,6 +83,8 @@
   <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic|Maven+Pro"
     rel="stylesheet" type="text/css">
   <link rel="stylesheet" type="text/css" href="/assets/fastruby_blog/application.css" />
+  <link rel="canonical" href="{{ site.domain_name }}{{ site.baseurl }}{{ page.url }}" />
+
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
     integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
     crossorigin="anonymous"></script>


### PR DESCRIPTION
Hey,

This PR fixes this problem: https://www.pivotaltracker.com/story/show/174855137 (all of our article are missing [canonical tags](https://www.semrush.com/blog/canonical-url-guide/#header2))

Please check it out.

Thanks! 